### PR TITLE
Minor tabulation and Doxygen comments fixes

### DIFF
--- a/include/dojo/Shader.h
+++ b/include/dojo/Shader.h
@@ -32,33 +32,33 @@ namespace Dojo
 		{
 			BU_NONE,
 
-			BU_TEXTURE_0,	///The texture currently bound to unit 0
+			BU_TEXTURE_0,	///<The texture currently bound to unit 0
 			BU_TEXTURE_N = BU_TEXTURE_0 + DOJO_MAX_TEXTURES-1,
 
-			BU_TEXTURE_0_DIMENSION, ///The dimensions in pixels of the texture currently bound to unit 0 (vec2)
+			BU_TEXTURE_0_DIMENSION, ///<The dimensions in pixels of the texture currently bound to unit 0 (vec2)
 			BU_TEXTURE_N_DIMENSION = BU_TEXTURE_0_DIMENSION + DOJO_MAX_TEXTURES-1,
 
 			BU_TEXTURE_0_TRANSFORM,
 			BU_TEXTURE_N_TRANSFORM = BU_TEXTURE_0_TRANSFORM + DOJO_MAX_TEXTURES-1,
 
-			BU_WORLD = BU_TEXTURE_0_DIMENSION + DOJO_MAX_TEXTURES,			///The world matrix
-			BU_VIEW,			///The view matrix
-			BU_PROJECTION,		///The projection matrix
-            BU_WORLDVIEW,
-			BU_WORLDVIEWPROJ,	///The complete transformation matrix
-			BU_OBJECT_COLOR,	///The object's color (vec4)
+			BU_WORLD = BU_TEXTURE_0_DIMENSION + DOJO_MAX_TEXTURES,			///<The world matrix
+			BU_VIEW,		///<The view matrix
+			BU_PROJECTION,		///<The projection matrix
+        		BU_WORLDVIEW,           ///<The world view matrix
+			BU_WORLDVIEWPROJ,	///<The complete transformation matrix
+			BU_OBJECT_COLOR,	///<The object's color (vec4)
 
-			BU_VIEW_DIRECTION,	///The current world-space direction of the view (vec3)
+			BU_VIEW_DIRECTION,	///<The current world-space direction of the view (vec3)
 			
-			BU_TIME,			///Time in seconds since the start of the program (float)
-			BU_TARGET_DIMENSION	///The dimensions in pixels of the currently bound target (vec2)
+			BU_TIME,		///<Time in seconds since the start of the program (float)
+			BU_TARGET_DIMENSION	///<The dimensions in pixels of the currently bound target (vec2)
 		};
 
 		///A VertexAttribute represents a "attribute" binding in a vertex shader
 		struct VertexAttribute
 		{
 			GLint location;
-			GLint count; ///the array size *for a single vertex*
+			GLint count; ///<The array size *for a single vertex*
 
 			VertexField builtInAttribute;
 


### PR DESCRIPTION
From http://www.stack.nl/~dimitri/doxygen/manual/docblocks.html in "_Putting documentation after members_":

> If you want to document the members of a file, struct, union, class, or enum, it is sometimes desired to place the documentation block after the member instead of before. For this purpose you have to put an additional < marker in the comment block. Note that this also works for the parameters of a function.

This change should probably be propagated in the rest of the source code. :)
